### PR TITLE
Compilerfehler für IFIL-Extras behoben.

### DIFF
--- a/extras/iflidiashow.a
+++ b/extras/iflidiashow.a
@@ -1,5 +1,5 @@
 
-	!src "..\godotlib.lib"
+	!src "../libraries/godotlib.lib"
 	*= $0801
 
 ; ------------------------------------------ 


### PR DESCRIPTION
Beim Compilieren wurde der folgende Fehler geworfen:

```
% gmake d81
...
acme -I libraries -f cbm  -o build/iflidiashow extras/iflidiashow.a
Error - File extras/iflidiashow.a, line 2 (Zone <untitled>): Cannot open input file.
gmake: *** [Makefile:216: build/iflidiashow] Fehler 1
%
```

Durch die Änderung der Einbindung wird dies korrigiert, allerdings weiß
ich nicht ob die Pfadangaben unter Windows auch funktionieren (`/` vs. `\`).
